### PR TITLE
Use base stage in execution stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ install:
 
 script:
   - make check
-  - make test
 
 after_success:
   - bash < (curl -s https://codecov.io/bash)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine3.9 AS base
+FROM python:3.7.3-alpine3.10 AS base
 
 RUN pip install -U pip
 
@@ -13,7 +13,7 @@ COPY requirements.txt .
 RUN pip wheel -r requirements.txt
 
 # Execution Stage
-FROM build
+FROM base
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
```shell
$ docker images
REPOSITORY          SIZE
new                 124MB
old                 298MB
```

[Rainist/python 버그](https://github.com/Rainist/python/pull/29)가 수정되었으므로 해당 쿠키커터를 통해 생성한 본 레포도 반영했습니다.